### PR TITLE
Fix login and added status indications

### DIFF
--- a/test.py
+++ b/test.py
@@ -7,28 +7,32 @@ url_for_books = "https://www.royalroad.com/my/bookmarks"
 url_for_check = "https://www.royalroad.com/fictions/latest-updates"
 
 payload = {
-	"ReturnUrl": "https://www.royalroad.com/home",
-	"Email": "***********",
-	"Password": "********",
-	"__RequestVerificationToken": "**************",
-	"Remember" : "false"
+  'Email': '***********',
+  'Password': '********'
 }
+
 i = 0
 with requests.Session() as s:
 	#auth
-	s.post(url_for_auth,data = payload)
-	#user_fictions
-	res = s.get(url_for_books)
-	soup = BeautifulSoup(res.text, "lxml")
-	fictions = [x.find("a",class_="font-red-sunglo bold").text for x in soup.find_all("h2",class_="fiction-title")]
-	while True:
-		#updated_fictions
-		res = s.get(url_for_check)
-		soup = BeautifulSoup(res.text, "lxml")
-		updated_fictions = [x.find("a").text for x in soup.find_all("h2",class_="fiction-title")]
-		for el in fictions:
-			if el in updated_fictions:
-				plyer.notification.notify( message='Вышля новая глава',title=el)
-		i += 1
-		print(f"Закончил проверку №{i}")
-		sleep(120)
+        res = s.post(url_for_auth, data=payload, allow_redirects=False)
+        if ".AspNetCore.Identity.Application" in res.headers['set-cookie']:
+                print("Successfully logged in.")
+        else:
+                print("Failed to log in.")
+        #user_fictions
+        res = s.get(url_for_books)
+        soup = BeautifulSoup(res.text, "lxml")
+        if "Bookmarks | Royal Road" in res.text:
+                print("Successfully got bookmarks.")
+        fictions = [x.find("a",class_="font-red-sunglo bold").text for x in soup.find_all("h2",class_="fiction-title")]
+        while True:
+                #updated_fictions
+                res = s.get(url_for_check)
+                soup = BeautifulSoup(res.text, "lxml")
+                updated_fictions = [x.find("a").text for x in soup.find_all("h2",class_="fiction-title")]
+                for el in fictions:
+                        if el in updated_fictions:
+                                plyer.notification.notify( message='Вышля новая глава',title=el)
+                i += 1
+                print(f"Закончил проверку №{i}")
+                sleep(120)


### PR DESCRIPTION
Login was failing due to the redirect that occurs on login no longer saving the set cookie needed for the session. Removing the redirect allows the session to get the cookies set during the redirect.